### PR TITLE
2x roots Old Roots Drop Chance

### DIFF
--- a/config/roots.cfg
+++ b/config/roots.cfg
@@ -47,7 +47,7 @@ general {
     I:infernalBulbDropChance=20
 
     # Old Roots will drop from tall grass with a 1/oldRootDropChance probability. [range: 0 ~ 32767, default: 40]
-    I:oldRootDropChance=40
+    I:oldRootDropChance=20
 
     # The number of ticks required to prepare a spell with a staff. [range: 1 ~ 32767, default: 20]
     I:staffChargeTicks=20
@@ -77,7 +77,7 @@ world {
     I:berriesDropChance=25
     I:dragonsEyeDropChance=10
     I:infernalBulbDropChance=20
-    I:oldRootDropChance=40
+    I:oldRootDropChance=20
     I:verdantSprigDropChance=30
 }
 


### PR DESCRIPTION
With the huge volume of potential drops from breaking grass, sometimes roots can get choked out. 1/40 is rarer than the author anticipated.
